### PR TITLE
Update to Tokio 0.3 or 1.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 log = "0.4.8"
 futures = "0.3.1"
 pin-utils = "0.1.0-alpha.4"
-tokio = {version = "0.2.11", optional = true, features = ["time"]}
+tokio = {version = ">= 0.3, < 2.0.0", optional = true, features = ["time"]}
 futures-timer = {version = "3.0.1", optional = true}
 
 [features]
@@ -25,7 +25,7 @@ timer-tokio = ["tokio"]
 timer-futures-timer = ["futures-timer"]
 
 [dev-dependencies]
-tokio = {version = "0.2.11", features = ["full"]}
+tokio = {version = ">= 0.3, < 2.0.0", features = ["full"]}
 async-std = {version = "1", features = ["attributes"]}
 
 [[example]]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -85,7 +85,7 @@ impl ThrottlePool {
 
 #[cfg(feature = "timer-tokio")]
 fn delay_for(dur: Duration) -> impl Future<Output = ()> {
-	tokio::time::delay_for(dur)
+	tokio::time::sleep(dur)
 }
 
 #[cfg(feature = "timer-futures-timer")]


### PR DESCRIPTION
Tokio changed the delay_for function to sleep in 0.3. Tests pass with Tokio 0.3, 1.2, and 1.4.

Resolves #7 